### PR TITLE
[Intro] 탭레이아웃 연동, 탭리스너, 버튼 이벤트 추가

### DIFF
--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/intro/IntroActivity.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/intro/IntroActivity.kt
@@ -1,12 +1,75 @@
 package com.stock.sns.zuzuclub_android.ui.intro
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
 import com.stock.sns.zuzuclub_android.R
+import com.stock.sns.zuzuclub_android.databinding.ActivityIntroBinding
+import com.stock.sns.zuzuclub_android.ui.login.LoginActivity
 
-class IntroActivity : AppCompatActivity() {
+class IntroActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
+    private lateinit var binding: ActivityIntroBinding
+    private lateinit var viewPager: ViewPager2
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_intro)
+        binding = ActivityIntroBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val pagerAdapter = ScreenSlidePagerAdapter(this)
+        viewPager = binding.aIntroVp
+        viewPager.adapter = pagerAdapter
+
+        val tabLayout = binding.aIntroTl
+        TabLayoutMediator(tabLayout, viewPager) { _, _ ->
+        }.attach()
+
+        tabLayout.addOnTabSelectedListener(this)
+
+        binding.aIntroTvStart.setOnClickListener {
+            val intent = Intent(this, LoginActivity::class.java)
+            startActivity(intent)
+        }
+    }
+
+    inner class ScreenSlidePagerAdapter(introActivity: IntroActivity) :
+        FragmentStateAdapter(introActivity) {
+        override fun getItemCount(): Int = NUM_PAGES
+
+        override fun createFragment(position: Int): Fragment {
+            return when (position) {
+                0 -> Intro1Fragment()
+                1 -> Intro2Fragment()
+                2 -> Intro3Fragment()
+                else -> {
+                    Intro4Fragment()
+                }
+            }
+        }
+
+    }
+
+    override fun onTabSelected(tab: TabLayout.Tab?) {
+        if (binding.aIntroVp.currentItem == 3) {
+            binding.aIntroTvStart.setTextColor(resources.getColor(R.color.zuzu_white, null))
+            binding.aIntroTvStart.setBackgroundResource(R.drawable.intro_btn_start_background)
+        } else {
+            binding.aIntroTvStart.setTextColor(resources.getColor(R.color.zuzu_orange, null))
+            binding.aIntroTvStart.setBackgroundResource(0)
+        }
+    }
+
+    override fun onTabUnselected(tab: TabLayout.Tab?) {
+    }
+
+    override fun onTabReselected(tab: TabLayout.Tab?) {
+    }
+
+    companion object {
+        private const val NUM_PAGES = 4
     }
 }


### PR DESCRIPTION
- 탭레이아웃에 어댑터 및 뷰페이저 연동
- 뷰페이저 어댑터에 탭을 넘기면 보여주는 프래그먼트 순서 설정 (createFragment)
- 탭레이아웃에 OnTabSelectedListener 설정 (마지막 프래그먼트에서 버튼 스타일 변경)
- 시작 버튼을 클릭하면 Login 화면으로 이동하는 로직 추가