### PR TITLE
[ChooseStock] 리싸이클러뷰 어댑터 적용 및 뷰모델 추가, 기타 작업 업데이트

### DIFF
--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/intro/IntroActivity.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/intro/IntroActivity.kt
@@ -31,7 +31,9 @@ class IntroActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
         tabLayout.addOnTabSelectedListener(this)
 
         binding.aIntroTvStart.setOnClickListener {
-            val intent = Intent(this, LoginActivity::class.java)
+            intent = Intent(this, LoginActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             startActivity(intent)
         }
     }

--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/ChooseStockActivity.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/ChooseStockActivity.kt
@@ -1,12 +1,35 @@
 package com.stock.sns.zuzuclub_android.ui.signup
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import com.stock.sns.zuzuclub_android.R
+import androidx.activity.viewModels
+import androidx.recyclerview.widget.GridLayoutManager
+import com.stock.sns.zuzuclub_android.databinding.ActivityChooseStockBinding
 
 class ChooseStockActivity : AppCompatActivity() {
+    private val binding by lazy { ActivityChooseStockBinding.inflate(layoutInflater) }
+    private val viewModel by viewModels<ChooseStockViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_choose_stock)
+        setContentView(binding.root)
+        initClickListener()
+
+        binding.aChooseStockRcv.apply {
+            layoutManager = GridLayoutManager(context, 2)
+            adapter = ChooseStockAdapter(viewModel.interestStock)
+        }
+    }
+
+    private fun initClickListener() {
+        val intent = Intent(this, StampActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        binding.aChooseStockTvNext.setOnClickListener {
+            startActivity(intent)
+        }
+        binding.aChooseStockTvSkip.setOnClickListener {
+            startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/ChooseStockAdapter.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/ChooseStockAdapter.kt
@@ -1,0 +1,33 @@
+package com.stock.sns.zuzuclub_android.ui.signup
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.stock.sns.zuzuclub_android.data.model.InterestData
+import com.stock.sns.zuzuclub_android.databinding.ItemInterestStockBinding
+
+class ChooseStockAdapter(private val stockList: ArrayList<InterestData>) : RecyclerView.Adapter<ChooseStockAdapter.ChooseStockViewHolder>() {
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ChooseStockViewHolder {
+        val binding = ItemInterestStockBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+
+        return ChooseStockViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = stockList.size
+
+    override fun onBindViewHolder(holder: ChooseStockViewHolder, position: Int) {
+        val stock = stockList[position].name
+        holder.bind(stock)
+    }
+
+    inner class ChooseStockViewHolder(binding: ItemInterestStockBinding) : RecyclerView.ViewHolder(binding.root) {
+        private val stockName = binding.iInterestStockTvName
+        fun bind(stock: String) {
+            stockName.text = stock
+        }
+    }
+}

--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/ChooseStockViewModel.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/ChooseStockViewModel.kt
@@ -1,0 +1,36 @@
+package com.stock.sns.zuzuclub_android.ui.signup
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.stock.sns.zuzuclub_android.data.model.InterestData
+import com.stock.sns.zuzuclub_android.data.model.getDummyMainInterestList
+
+class ChooseStockViewModel : ViewModel() {
+    private var _interestStock = MutableLiveData<ArrayList<InterestData>>()
+    val interestStock : ArrayList<InterestData> = getDummyMainInterestList()
+
+    init {
+        interestStock.add(InterestData(1, "삼성전자"))
+        interestStock.add(InterestData(1,"데브시스터즈"))
+        interestStock.add(InterestData(1,"뱅크샐러드"))
+        interestStock.add(InterestData(1,"효성ITX"))
+        interestStock.add(InterestData(1,"NAVER"))
+        interestStock.add(InterestData(1,"현대차"))
+        interestStock.add(InterestData(1,"한화생명"))
+        interestStock.add(InterestData(1,"SK이노베이션"))
+        interestStock.add(InterestData(1,"동원시스템즈"))
+        interestStock.add(InterestData(1,"HMM"))
+        interestStock.add(InterestData(1, "삼성전자"))
+        interestStock.add(InterestData(1,"데브시스터즈"))
+        interestStock.add(InterestData(1,"뱅크샐러드"))
+        interestStock.add(InterestData(1,"효성ITX"))
+        interestStock.add(InterestData(1,"NAVER"))
+        interestStock.add(InterestData(1,"현대차"))
+        interestStock.add(InterestData(1,"한화생명"))
+        interestStock.add(InterestData(1,"SK이노베이션"))
+        interestStock.add(InterestData(1,"동원시스템즈"))
+        interestStock.add(InterestData(1,"HMM"))
+        _interestStock.postValue(interestStock)
+    }
+
+}

--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/StampActivity.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/StampActivity.kt
@@ -1,12 +1,22 @@
 package com.stock.sns.zuzuclub_android.ui.signup
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import com.stock.sns.zuzuclub_android.R
+import com.stock.sns.zuzuclub_android.databinding.ActivityStampBinding
+import com.stock.sns.zuzuclub_android.ui.MainActivity
 
 class StampActivity : AppCompatActivity() {
+    val binding by lazy { ActivityStampBinding.inflate(layoutInflater) }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_stamp)
+        setContentView(binding.root)
+
+        binding.aStampTvNext.setOnClickListener {
+            intent = Intent(this, MainActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/TermsActivity.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/signup/TermsActivity.kt
@@ -19,7 +19,10 @@ class TermsActivity : AppCompatActivity(), CompoundButton.OnCheckedChangeListene
     private fun initClickListener(){
         binding.aTermsIvBack.setOnClickListener { finish() }
         binding.aTermsTvNext.setOnClickListener {
-            startActivity(Intent(this, ChooseStockActivity::class.java))
+            intent = Intent(this, ChooseStockActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/res/layout/activity_choose_stock.xml
+++ b/app/src/main/res/layout/activity_choose_stock.xml
@@ -30,14 +30,17 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/a_choose_stock_rcv"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginTop="160dp"
+        android:paddingBottom="50dp"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:listitem="@layout/item_interest_stock" />
 
     <TextView

--- a/app/src/main/res/layout/item_interest_stock.xml
+++ b/app/src/main/res/layout/item_interest_stock.xml
@@ -6,7 +6,7 @@
     android:layout_margin="8dp">
 
     <TextView
-        android:id="@+id/a_choose_stock_item_tv"
+        android:id="@+id/i_interest_stock_tv_name"
         android:layout_width="152dp"
         android:layout_height="48dp"
         android:text="종목명"


### PR DESCRIPTION
- ChooseStockActivity의 ChooseStockAdapter, ChooseStockViewModel 추가 및 적용
- ChooseStockActivity의 뷰 클릭 리스너 설정하는 initClickListener() 메서드 추가
- activity_choose_stock.xml의 리싸이클러뷰 아이디 설정, 크기 조정, 제약 조건 추가, 하단 패딩 추가
- IntroActivity, TermsActivity, StampActivity에 액티비티 스택 정리하는 Intent Flag 추가