### PR TITLE
[Search] Home -> Search 연결, 네비게이션 수정

### DIFF
--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/MainActivity.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/MainActivity.kt
@@ -3,8 +3,10 @@ package com.stock.sns.zuzuclub_android.ui
 import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.view.WindowManager
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
@@ -30,12 +32,13 @@ class MainActivity : AppCompatActivity() {
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.fcv_main) as NavHostFragment
         val navController = navHostFragment.navController
         navController.addOnDestinationChangedListener { _, destination, _ ->
-            if (destination.id == R.id.navigation_post) {
+            if (destination.id == R.id.navigation_post || destination.id == R.id.navigation_search) {
                 binding.btnvView.visibility = View.GONE
             } else {
                 binding.btnvView.visibility = View.VISIBLE
             }
         }
+
         binding.btnvView.setupWithNavController(navController)
         binding.btnvView.itemIconTintList = null
     }

--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/home/HomeFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.MutableLiveData
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stock.sns.zuzuclub_android.R
@@ -91,5 +92,9 @@ class HomeFragment : Fragment() {
                 binding.rvHomeInterest.adapter = HomeInterestAdapter(interestData)
             }
         )
+
+        binding.imgHomeSearch.setOnClickListener {
+            findNavController().navigate(R.id.navigation_search)
+        }
     }
 }

--- a/app/src/main/java/com/stock/sns/zuzuclub_android/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/stock/sns/zuzuclub_android/ui/search/SearchFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.stock.sns.zuzuclub_android.databinding.FragmentSearchBinding
 
 class SearchFragment : Fragment() {
@@ -20,8 +21,17 @@ class SearchFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-
+        initUI()
         return binding.root
+    }
+
+    private fun initUI(){
+        binding.fSearchTl.addTab(binding.fSearchTl.newTab().setText("종목"))
+        binding.fSearchTl.addTab(binding.fSearchTl.newTab().setText("유저"))
+
+        binding.fSearchTvCancel.setOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
 }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -41,20 +41,6 @@
         app:layout_constraintStart_toEndOf="@+id/f_search_et"
         app:layout_constraintTop_toTopOf="@id/f_search_et" />
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline4"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="304dp" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline5"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="352dp" />
-
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/f_search_tl"
         android:layout_width="0dp"
@@ -69,21 +55,7 @@
         app:tabIndicatorColor="@color/zuzu_orange"
         app:tabIndicatorHeight="4dp"
         app:tabTextAppearance="@style/Contents14Regular"
-        app:tabTextColor="@color/zuzu_black_100">
-
-        <com.google.android.material.tabs.TabItem
-            android:id="@+id/f_search_tab_stock"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingBottom="4dp"
-            android:text="종목" />
-
-        <com.google.android.material.tabs.TabItem
-            android:id="@+id/f_search_tab_user"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="유저" />
-    </com.google.android.material.tabs.TabLayout>
+        app:tabTextColor="@color/zuzu_black_100"/>
 
     <View
         android:id="@+id/f_search_v_line"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -12,7 +12,6 @@
         android:label="Home"
         tools:layout="@layout/fragment_home" />
 
-
     <fragment
         android:id="@+id/navigation_feed"
         android:name="com.stock.sns.zuzuclub_android.ui.feed.FeedFragment"
@@ -42,5 +41,11 @@
         android:name="com.stock.sns.zuzuclub_android.ui.profile.ProfileFragment"
         android:label="Profile"
         tools:layout="@layout/fragment_profile" />
+
+    <fragment
+        android:id="@+id/navigation_search"
+        android:name="com.stock.sns.zuzuclub_android.ui.search.SearchFragment"
+        android:label="Search"
+        tools:layout="@layout/fragment_search" />
 
 </navigation>


### PR DESCRIPTION
- MainActivity의 바텀네비게이션뷰 숨기는 로직에 검색 레이아웃 추가
- 홈의 돋보기 아이콘에 클릭 리스너 달고 search 화면으로 navigate하는 코드 추가
- search의 탭 아이템과 취소 버튼을 init하는 initUI 메서드 적용
- search 레이아웃의 가이드라인, 탭아이템 삭제
- main_navigation.xml에 search fragment 추가